### PR TITLE
RBX 2.2.6 ToolSets

### DIFF
--- a/lib/lani.rb
+++ b/lib/lani.rb
@@ -1,4 +1,4 @@
-RBX = Rubinius::ToolSet.current::TS
+RBX = Rubinius::ToolSets.current::ToolSet
 
 require "lani/version"
 require "lani/parser"


### PR DESCRIPTION
In Rubinius 2.2.6 `Rubinius::ToolSet.current::TS` throws a unitialized constant error.
